### PR TITLE
Bumping version and checksum to 1.2.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,11 +15,11 @@ semaphor_deb_package_url: "https://spideroak.com/releases/semaphor/debian"
 # This version number will need to be manually bumped as new releases are
 # issued. Haven't found a decent API yet for reliably determing the most
 # recent version available and using that.
-semaphor_version: "1.2.1"
+semaphor_version: "1.2.3"
 
 # Hard-coded as from v1.2.1; the Semaphor project does not use GPG signatures
 # for verification (yet), so SHA256 checksum over TLS is the best we've got.
-semaphor_deb_package_sha256: d6fbd2497b4d0368d4c804b16aa9631bb05de2d3be966fa0f17d87bb7caaff3a
+semaphor_deb_package_sha256: ad651cb6000efde4c768f0c10aa7afac6f9510c8bfa486fee4877f615c63175b
 
 semaphor_deb_package_filename: "{{ 'semaphor_'+semaphor_version+'_amd64.deb' }}"
 semaphor_download_directory: /usr/local/src


### PR DESCRIPTION
Pretty straight-forward PR, those semaphor folk need to move to GPG signatures :(