### PR TITLE
Bumps Semaphor version to 1.2.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,11 +15,11 @@ semaphor_deb_package_url: "https://spideroak.com/releases/semaphor/debian"
 # This version number will need to be manually bumped as new releases are
 # issued. Haven't found a decent API yet for reliably determing the most
 # recent version available and using that.
-semaphor_version: "1.2.3"
+semaphor_version: "1.2.5"
 
-# Hard-coded as from v1.2.1; the Semaphor project does not use GPG signatures
+# Hard-coded SHA256 checksum; the Semaphor project does not use GPG signatures
 # for verification (yet), so SHA256 checksum over TLS is the best we've got.
-semaphor_deb_package_sha256: ad651cb6000efde4c768f0c10aa7afac6f9510c8bfa486fee4877f615c63175b
+semaphor_deb_package_sha256: ea73d86020564889cdc5a03afd65acfd7483cbc0760281bbeabd1f8ddd59987f
 
 semaphor_deb_package_filename: "{{ 'semaphor_'+semaphor_version+'_amd64.deb' }}"
 semaphor_download_directory: /usr/local/src


### PR DESCRIPTION
Nudging up the hard-coded version value and hard-coded SHA256 checksum.